### PR TITLE
docs(readme): fix typo and broken link

### DIFF
--- a/CODING_STYLE.md
+++ b/CODING_STYLE.md
@@ -37,7 +37,7 @@ The coding style is inspired by the [Google C++ Style Guide](https://google.gith
 
 ### Namespaces
 
-- Each class ùust be in the `tdl` namespace.
+- Each class must be in the `tdl` namespace.
 - The namespace must be in lowercase. (e.g. `namespace tdl`).
 - Do not use any `using namespace` statement in header or source files.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ The instructions describe the main tdl repository `but it works the same way for
 
 ### Commit message format
 
-The commit messages format is inspired from [Angular commit message convention]( https://gist.github.com/brianclements/841ea7bffdb01346392c)
+The commit messages format is inspired from [Angular commit message convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/)
 
 When commiting changes, the following structure should be used in the title and associated description of said commit:
 


### PR DESCRIPTION
Corrected a minor typing error in the README file and updated a broken link to the correct URL.

No functional changes.